### PR TITLE
Genomic annotations query through pgsql functions

### DIFF
--- a/app/medcoLoader.go
+++ b/app/medcoLoader.go
@@ -20,23 +20,39 @@ const (
 	optionEntryPointIdx      = "entryPointIdx"
 	optionEntryPointIdxShort = "entry"
 
-	// database settings
-	optionDBhost      = "dbHost"
-	optionDBhostShort = "dbH"
+	// i2b2 database settings
+	optionI2b2DBhost      = "i2b2DbHost"
+	optionI2b2DBhostShort = "i2b2H"
 
-	optionDBport      = "dbPort"
-	optionDBportShort = "dbP"
+	optionI2b2DBport      = "i2b2DbPort"
+	optionI2b2DBportShort = "i2b2P"
 
-	optionDBname      = "dbName"
-	optionDBnameShort = "dbN"
+	optionI2b2DBname      = "i2b2DbName"
+	optionI2b2DBnameShort = "i2b2N"
 
-	optionDBuser      = "dbUser"
-	optionDBuserShort = "dbU"
+	optionI2b2DBuser      = "i2b2DbUser"
+	optionI2b2DBuserShort = "i2b2U"
 
-	optionDBpassword      = "dbPassword"
-	optionDBpasswordShort = "dbPw"
+	optionI2b2DBpassword      = "i2b2DbPassword"
+	optionI2b2DBpasswordShort = "i2b2Pw"
 
 	// #---- V0 ----#
+
+	// genomic annotations database settings
+	optionGaDBhost      = "gaDbHost"
+	optionGaDBhostShort = "gaH"
+
+	optionGaDBport      = "gaDbPort"
+	optionGaDBportShort = "gaP"
+
+	optionGaDBname      = "gaDbName"
+	optionGaDBnameShort = "gaN"
+
+	optionGaDBuser      = "gaDbUser"
+	optionGaDBuserShort = "gaU"
+
+	optionGaDBpassword      = "gaDbPassword"
+	optionGaDBpasswordShort = "gaPw"
 
 	// DefaultOntologyClinical is the name of the default clinical file (dataset)
 	DefaultOntologyClinical = "../../data/genomic/tcga_cbio/clinical_data.csv"
@@ -111,29 +127,29 @@ func main() {
 			EnvVar: "UNLYNX_GROUP_FILE_IDX",
 		},
 		cli.StringFlag{
-			Name:   optionDBhost + ", " + optionDBhostShort,
-			Usage:  "Database hostname",
-			EnvVar: "DB_HOST",
+			Name:   optionI2b2DBhost + ", " + optionI2b2DBhostShort,
+			Usage:  "I2B2 database hostname",
+			EnvVar: "I2B2_DB_HOST",
 		},
 		cli.IntFlag{
-			Name:   optionDBport + ", " + optionDBportShort,
-			Usage:  "Database port",
-			EnvVar: "DB_PORT",
+			Name:   optionI2b2DBport + ", " + optionI2b2DBportShort,
+			Usage:  "I2B2 database port",
+			EnvVar: "I2B2_DB_PORT",
 		},
 		cli.StringFlag{
-			Name:   optionDBname + ", " + optionDBnameShort,
-			Usage:  "Database name",
-			EnvVar: "DB_NAME",
+			Name:   optionI2b2DBname + ", " + optionI2b2DBnameShort,
+			Usage:  "I2B2 database name",
+			EnvVar: "I2B2_DB_NAME",
 		},
 		cli.StringFlag{
-			Name:   optionDBuser + ", " + optionDBuserShort,
-			Usage:  "Database user",
-			EnvVar: "DB_USER",
+			Name:   optionI2b2DBuser + ", " + optionI2b2DBuserShort,
+			Usage:  "I2B2 database user",
+			EnvVar: "I2B2_DB_USER",
 		},
 		cli.StringFlag{
-			Name:   optionDBpassword + ", " + optionDBpasswordShort,
-			Usage:  "Database password",
-			EnvVar: "DB_PASSWORD",
+			Name:   optionI2b2DBpassword + ", " + optionI2b2DBpasswordShort,
+			Usage:  "I2B2 database password",
+			EnvVar: "I2B2_DB_PASSWORD",
 		},
 	}
 
@@ -166,6 +182,31 @@ func main() {
 			Name:  optionOutputPath + ", " + optionOuputPathShort,
 			Value: DefaultOutputPath,
 			Usage: "Output path for the .csv files",
+		},
+		cli.StringFlag{
+			Name:   optionGaDBhost + ", " + optionGaDBhostShort,
+			Usage:  "Genomic annotations database hostname",
+			EnvVar: "GA_DB_HOST",
+		},
+		cli.IntFlag{
+			Name:   optionGaDBport + ", " + optionGaDBportShort,
+			Usage:  "Genomic annotations database port",
+			EnvVar: "GA_DB_PORT",
+		},
+		cli.StringFlag{
+			Name:   optionGaDBname + ", " + optionGaDBnameShort,
+			Usage:  "Genomic annotations database name",
+			EnvVar: "GA_DB_NAME",
+		},
+		cli.StringFlag{
+			Name:   optionGaDBuser + ", " + optionGaDBuserShort,
+			Usage:  "Genomic annotations database user",
+			EnvVar: "GA_DB_USER",
+		},
+		cli.StringFlag{
+			Name:   optionGaDBpassword + ", " + optionGaDBpasswordShort,
+			Usage:  "Genomic annotations database password",
+			EnvVar: "GA_DB_PASSWORD",
 		},
 	}
 	loaderFlagsv0 = append(loaderFlagsCommon, loaderFlagsv0...)

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -30,10 +30,15 @@ RUN apk add --no-cache postgresql-client
 ENV LOG_LEVEL=5 \
     UNLYNX_GROUP_FILE_PATH=/medco-configuration/group.toml \
     UNLYNX_GROUP_FILE_IDX=0 \
-    DB_HOST=localhost \
-    DB_PORT=5432 \
-    DB_NAME=i2b2medco \
-    DB_USER=i2b2 \
-    DB_PASSWORD=i2b2
+    I2B2_DB_HOST=localhost \
+    I2B2_DB_PORT=5432 \
+    I2B2_DB_NAME=i2b2medco \
+    I2B2_DB_USER=i2b2 \
+    I2B2_DB_PASSWORD=i2b2 \
+    GA_DB_HOST=localhost \
+    GA_DB_PORT=5432 \
+    GA_DB_NAME=gamedcosrv \
+    GA_DB_USER=genomicannotations \
+    GA_DB_PASSWORD=genomicannotations
 
 ENTRYPOINT ["medco-loader"]

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -13,11 +13,16 @@ services:
       - LOG_LEVEL=3
       - UNLYNX_GROUP_FILE_PATH=/medco-configuration/group.toml
       - UNLYNX_GROUP_FILE_IDX=0
-      - DB_HOST=localhost
-      - DB_PORT=5432
-      - DB_NAME=i2b2medcosrv0
-      - DB_USER=i2b2
-      - DB_PASSWORD=i2b2
+      - I2B2_DB_HOST=localhost
+      - I2B2_DB_PORT=5432
+      - I2B2_DB_NAME=i2b2medcosrv0
+      - I2B2_DB_USER=i2b2
+      - I2B2_DB_PASSWORD=i2b2
+      - GA_DB_HOST=localhost
+      - GA_DB_PORT=5432
+      - GA_DB_NAME=gamedcosrv0
+      - GA_DB_USER=genomicannotations
+      - GA_DB_PASSWORD=genomicannotations
     command: >-
       -debug 2 v0 --group /medco-configuration/group.toml --entryPointIdx 0
       --ont_clinical /dataset/tcga_cbio/clinical_data.csv --sen /dataset/sensitive.txt

--- a/loader/genomic/loaderGenomic.go
+++ b/loader/genomic/loaderGenomic.go
@@ -475,9 +475,9 @@ func GenerateLoadingOntologyScript(i2b2DB loader.DBSettings, gaDB loader.DBSetti
 
 	loading += `UPDATE medco_ont.table_access SET c_visualattributes = 'CH ' WHERE c_table_cd = 'E2ETEST';` + "\n"
 
-	loading += `ALTER TABLE medco_ont.genomic OWNER TO i2b2;
-    			ALTER TABLE medco_ont.clinical_sensitive OWNER TO i2b2;
-    			ALTER TABLE medco_ont.clinical_non_sensitive OWNER TO i2b2;` + "\n"
+	loading += `ALTER TABLE medco_ont.genomic OWNER TO $I2B2_DB_USER;
+    			ALTER TABLE medco_ont.clinical_sensitive OWNER TO $I2B2_DB_USER;
+    			ALTER TABLE medco_ont.clinical_non_sensitive OWNER TO $I2B2_DB_USER;` + "\n"
 
 	loading += "COMMIT;\n"
 	loading += "EOSQL"
@@ -502,11 +502,11 @@ func GenerateLoadingOntologyScript(i2b2DB loader.DBSettings, gaDB loader.DBSetti
 				gene_value character varying(255) NOT NULL PRIMARY KEY);
 		
 				-- permissions
-				ALTER TABLE genomic_annotations.genomic_annotations OWNER TO genomicannotations;
-				ALTER TABLE genomic_annotations.annotation_names OWNER TO genomicannotations;
-				ALTER TABLE genomic_annotations.gene_values OWNER TO genomicannotations;
-				GRANT ALL on schema genomic_annotations to genomicannotations;
-				GRANT ALL privileges on all tables in schema genomic_annotations to genomicannotations;` + "\n"
+				ALTER TABLE genomic_annotations.genomic_annotations OWNER TO $GA_DB_USER;
+				ALTER TABLE genomic_annotations.annotation_names OWNER TO $GA_DB_USER;
+				ALTER TABLE genomic_annotations.gene_values OWNER TO $GA_DB_USER;
+				GRANT ALL on schema genomic_annotations to $GA_DB_USER;
+				GRANT ALL privileges on all tables in schema genomic_annotations to $GA_DB_USER;` + "\n"
 
 	//TODO: Delete this please
 	loading += "TRUNCATE " + TablenamesOntology[2] + ";\n"

--- a/loader/genomic/loaderGenomic_test.go
+++ b/loader/genomic/loaderGenomic_test.go
@@ -171,7 +171,7 @@ func TestReplayDataset(t *testing.T) {
 
 func TestGenerateLoadingScript(t *testing.T) {
 	dbSettings := loader.DBSettings{DBhost: "localhost", DBport: 5434, DBname: "medcodeployment", DBuser: "postgres", DBpassword: "prigen2017"}
-	err := loadergenomic.GenerateLoadingOntologyScript(dbSettings)
+	err := loadergenomic.GenerateLoadingOntologyScript(dbSettings, dbSettings)
 	assert.True(t, err == nil)
 	err = loadergenomic.GenerateLoadingDataScript(dbSettings)
 	assert.True(t, err == nil)

--- a/loader/i2b2/loaderI2B2.go
+++ b/loader/i2b2/loaderI2B2.go
@@ -125,7 +125,7 @@ func generateOutputFiles(folderPath string) {
 }
 
 // LoadI2B2Data it's the main function that performs a full conversion and loading of the I2B2 data
-func LoadI2B2Data(el *onet.Roster, entryPointIdx int, directory string, files Files, allSensitive bool, mapSensitive map[string]struct{}, databaseS loader.DBSettings, empty bool) error {
+func LoadI2B2Data(el *onet.Roster, entryPointIdx int, directory string, files Files, allSensitive bool, mapSensitive map[string]struct{}, i2b2DB loader.DBSettings, empty bool) error {
 	InputFilePaths = make(map[string]string)
 	OutputFilePaths = make(map[string]FileInfo)
 	OntologyFilesPaths = make([]string, 0)
@@ -234,7 +234,7 @@ func LoadI2B2Data(el *onet.Roster, entryPointIdx int, directory string, files Fi
 
 	log.Lvl2("--- Finished converting OBSERVATION_FACT ---")
 
-	err = GenerateLoadingDataScript(databaseS)
+	err = GenerateLoadingDataScript(i2b2DB)
 	if err != nil {
 		log.Fatal("Error while generating the loading data .sh file", err)
 		return err
@@ -254,14 +254,14 @@ func LoadI2B2Data(el *onet.Roster, entryPointIdx int, directory string, files Fi
 }
 
 // GenerateLoadingDataScript creates a load dataset .sql script (deletes the data in the corresponding tables and reloads the new 'protected' data)
-func GenerateLoadingDataScript(databaseS loader.DBSettings) error {
+func GenerateLoadingDataScript(i2b2DB loader.DBSettings) error {
 	fp, err := os.Create(FileBashPath)
 	if err != nil {
 		return err
 	}
 
-	loading := `#!/usr/bin/env bash` + "\n" + "\n" + `PGPASSWORD=` + databaseS.DBpassword + ` psql -v ON_ERROR_STOP=1 -h "` + databaseS.DBhost +
-		`" -U "` + databaseS.DBuser + `" -p ` + strconv.FormatInt(int64(databaseS.DBport), 10) + ` -d "` + databaseS.DBname + `" <<-EOSQL` + "\n"
+	loading := `#!/usr/bin/env bash` + "\n" + "\n" + `PGPASSWORD=` + i2b2DB.DBpassword + ` psql -v ON_ERROR_STOP=1 -h "` + i2b2DB.DBhost +
+		`" -U "` + i2b2DB.DBuser + `" -p ` + strconv.FormatInt(int64(i2b2DB.DBport), 10) + ` -d "` + i2b2DB.DBname + `" <<-EOSQL` + "\n"
 
 	loading += "BEGIN;\n"
 


### PR DESCRIPTION
The main modifications pertain the creation of the ontology loading script. Now it creates the genomic annotation tables in a dedicated DB, and creates also the stored functions to query them. The cli had to be changed to introduce the parameters related to the genomic annotations DB. There is also some refactoring and renaming.