### PR TITLE
changed genomic annotations user and database to medcoconnector

### DIFF
--- a/app/medcoLoader.go
+++ b/app/medcoLoader.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/urfave/cli"
 	"os"
+
+	"github.com/urfave/cli"
 
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
@@ -186,27 +187,27 @@ func main() {
 		cli.StringFlag{
 			Name:   optionGaDBhost + ", " + optionGaDBhostShort,
 			Usage:  "Genomic annotations database hostname",
-			EnvVar: "GA_DB_HOST",
+			EnvVar: "MC_DB_HOST",
 		},
 		cli.IntFlag{
 			Name:   optionGaDBport + ", " + optionGaDBportShort,
 			Usage:  "Genomic annotations database port",
-			EnvVar: "GA_DB_PORT",
+			EnvVar: "MC_DB_PORT",
 		},
 		cli.StringFlag{
 			Name:   optionGaDBname + ", " + optionGaDBnameShort,
 			Usage:  "Genomic annotations database name",
-			EnvVar: "GA_DB_NAME",
+			EnvVar: "MC_DB_NAME",
 		},
 		cli.StringFlag{
 			Name:   optionGaDBuser + ", " + optionGaDBuserShort,
 			Usage:  "Genomic annotations database user",
-			EnvVar: "GA_DB_USER",
+			EnvVar: "MC_DB_USER",
 		},
 		cli.StringFlag{
 			Name:   optionGaDBpassword + ", " + optionGaDBpasswordShort,
 			Usage:  "Genomic annotations database password",
-			EnvVar: "GA_DB_PASSWORD",
+			EnvVar: "MC_DB_PASSWORD",
 		},
 	}
 	loaderFlagsv0 = append(loaderFlagsCommon, loaderFlagsv0...)

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -35,10 +35,10 @@ ENV LOG_LEVEL=5 \
     I2B2_DB_NAME=i2b2medco \
     I2B2_DB_USER=i2b2 \
     I2B2_DB_PASSWORD=i2b2 \
-    GA_DB_HOST=localhost \
-    GA_DB_PORT=5432 \
-    GA_DB_NAME=gamedcosrv \
-    GA_DB_USER=genomicannotations \
-    GA_DB_PASSWORD=genomicannotations
+    MC_DB_HOST=localhost \
+    MC_DB_PORT=5432 \
+    MC_DB_NAME=medcoconnectorsrv \
+    MC_DB_USER=medcoconnector \
+    MC_DB_PASSWORD=medcoconnector
 
 ENTRYPOINT ["medco-loader"]

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -18,11 +18,11 @@ services:
       - I2B2_DB_NAME=i2b2medcosrv0
       - I2B2_DB_USER=i2b2
       - I2B2_DB_PASSWORD=i2b2
-      - GA_DB_HOST=localhost
-      - GA_DB_PORT=5432
-      - GA_DB_NAME=gamedcosrv0
-      - GA_DB_USER=genomicannotations
-      - GA_DB_PASSWORD=genomicannotations
+      - MC_DB_HOST=localhost
+      - MC_DB_PORT=5432
+      - MC_DB_NAME=medcoconnectorsrv0
+      - MC_DB_USER=medcoconnector
+      - MC_DB_PASSWORD=medcoconnector
     command: >-
       -debug 2 v0 --group /medco-configuration/group.toml --entryPointIdx 0
       --ont_clinical /dataset/tcga_cbio/clinical_data.csv --sen /dataset/sensitive.txt

--- a/loader/genomic/loaderGenomic.go
+++ b/loader/genomic/loaderGenomic.go
@@ -6,18 +6,19 @@ import (
 	"encoding/binary"
 	"encoding/csv"
 	"errors"
-	"github.com/ldsec/medco-loader/loader"
-	"github.com/ldsec/medco-loader/loader/identifiers"
-	"github.com/ldsec/medco-unlynx/services"
-	"github.com/ldsec/unlynx/lib"
-	"go.dedis.ch/onet/v3"
-	"go.dedis.ch/onet/v3/log"
 	"io"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ldsec/medco-loader/loader"
+	"github.com/ldsec/medco-loader/loader/identifiers"
+	servicesmedco "github.com/ldsec/medco-unlynx/services"
+	libunlynx "github.com/ldsec/unlynx/lib"
+	"go.dedis.ch/onet/v3"
+	"go.dedis.ch/onet/v3/log"
 )
 
 func init() {
@@ -515,11 +516,11 @@ func GenerateLoadingOntologyScript(i2b2DB loader.DBSettings, gaDB loader.DBSetti
 				gene_value character varying(255) NOT NULL PRIMARY KEY);
 		
 				-- permissions
-				ALTER TABLE genomic_annotations.genomic_annotations OWNER TO $GA_DB_USER;
-				ALTER TABLE genomic_annotations.annotation_names OWNER TO $GA_DB_USER;
-				ALTER TABLE genomic_annotations.gene_values OWNER TO $GA_DB_USER;
-				GRANT ALL on schema genomic_annotations to $GA_DB_USER;
-				GRANT ALL privileges on all tables in schema genomic_annotations to $GA_DB_USER;` + "\n"
+				ALTER TABLE genomic_annotations.genomic_annotations OWNER TO $MC_DB_USER;
+				ALTER TABLE genomic_annotations.annotation_names OWNER TO $MC_DB_USER;
+				ALTER TABLE genomic_annotations.gene_values OWNER TO $MC_DB_USER;
+				GRANT ALL on schema genomic_annotations to $MC_DB_USER;
+				GRANT ALL privileges on all tables in schema genomic_annotations to $MC_DB_USER;` + "\n"
 
 	//TODO: Delete this please
 	loading += "TRUNCATE " + TablenamesOntology[2] + ";\n"


### PR DESCRIPTION
As new schemata will be added to the medco connector database, genomicannotation postgres user and gamedcosrv database are renamed respectively medcoconnector and medcoconnectorsrv respectively.

These names more generic and show the direct link between this DB and the medco connector.

The renamed DB would store two schemata: genomic_annotations and query_tools